### PR TITLE
Unify API-based inference for weave.py

### DIFF
--- a/weave.py
+++ b/weave.py
@@ -78,7 +78,7 @@ class ProgressBarStreamer(BaseStreamer):
         self.next_tokens_are_prompt = True
 
 
-def load_generator(model_name="mistralai/Mistral-7B-v0.1", load_dtype="fp16"):
+def load_generator(model_name="mistralai/Mistral-7B-v0.1", load_dtype="int8"):
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     tokenizer.truncation_side = "left"
     tokenizer.padding_side = "left"
@@ -246,7 +246,7 @@ def generate_outputs_api(api_base, api_key, model_name, text, n_tokens, n=1, por
     response = requests.post(api_base,
                              headers=header,
                              data=json.dumps(payload))
-    print("GEN API RESPONSE:", response.json())
+    # print("GEN API RESPONSE:", response.json())
     # return completion.json()["choices"][0]["text"]
     texts = [choice["text"] for choice in response.json()["choices"]]
     return texts
@@ -386,7 +386,7 @@ def evaluate_outputs_api(api_base, api_key, model_name, score_prompt_fns, texts,
                                  headers=header,
                                  data=json.dumps(payload))
         choices = []
-        print("EVAL API RESPONSE:", response.json())
+        # print("EVAL API RESPONSE:", response.json())
         for choice in response.json()["choices"]:
             choice_o = Choice()
             mocklogprobs_o = MockLogProbs()

--- a/weave.py
+++ b/weave.py
@@ -596,11 +596,11 @@ def weave_tree_search(
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--gen-api-base", help="The base URL for the generator model API",
-                        default="http://localhost:5000/v1/completions")
+                        default=None)
     parser.add_argument("--gen-api-key", help="API key for the generator model API",
                         default=None)
     parser.add_argument("--eval-api-base", help="The base URL for the evaluation model API",
-                        default="http://localhost:5000/v1/completions")
+                        default=None)
     parser.add_argument("--eval-api-key", help="API key for the evaluation model API",
                         default=None)
     parser.add_argument("--gen-model-name", help="The inference engine to use for generation")


### PR DESCRIPTION
Currently, `weave.py` contains separate functions to infer using OpenAI or VLLM. But both of these APIs, as well as a number of others, are based on the [OpenAI v1 completions API](https://platform.openai.com/docs/api-reference/completions). Supporting arbitrary APIs is just a matter of changing base url and API key.

I made some changes to `weave.py` inference functions and args to support this. Examples to try:

- Business as usual: `python weave.py --gen-model-name mistralai/Mistral-7B-v0.1 --eval-model-name jdpressman/minihf_evaluator_mistral_7b_v0.1`
- Generating with a local model, evaluating with an OpenAI model: `python weave.py --gen-model-name openai-community/gpt2 --eval-model-name davinci-002 --eval-api-base https://api.openai.com/v1/completions --eval-api-key $OPENAI_API_KEY`
  - you'll need to comment out `repetition_penalty` and `top_k` in the `evaluate_outputs_api` payload to get it to work
- Generating with a model hosted on Together AI, evaluating with a model running on a local llama.cpp server: `python weave.py --gen-model-name mistralai/Mistral-7B-v0.1 --gen-api-base https://api.together.xyz/v1/completions --gen-api-key $TOGETHERAI_API_KEY --eval-model-name Meta-Llama-3-8B-Q4_5_M --eval-api-base http://localhost:5000/v1/completions`
  - you'll need to comment out `seed` in the `generate_outputs_api` payload to get it to work

It's not ideal that getting certain APIs to work requires so much commenting, but I'd prefer to handle that via config files rather than tacking on more command line args, and that seems like a job for a separate PR.